### PR TITLE
Improved error handling #2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,10 @@ extern crate crossbeam;
 
 pub mod read;
 pub mod write;
+
+fn unwrap_or_resume_unwind<V>(value: Result<V, Box<dyn std::any::Any + Send>>) -> V {
+    match value {
+        Ok(value) => value,
+        Err(error) => std::panic::resume_unwind(error),
+    }
+}


### PR DESCRIPTION
Both read and write did not handle errors properly. In particular,
errors happening in either the functions passed into thread_io by the
client caused unexpected panics or hangs.

Added a bunch of tests to handle the various conditions, and improved
some existing tests. Ensured as much as possible that the most
informative errors is returned in all cases.