### PR TITLE
Bump crossbeam to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["io", "thread", "concurrency"]
 edition = "2018"
 
 [dependencies]
-crossbeam = "0.7"
+crossbeam = "0.8"
 
 [features]
 crossbeam_channel = []


### PR DESCRIPTION
crossbeam 0.8 depends on recent versions of memoffset, which avoids reading of uninitialized memory (Gilnaa/memoffset#24).

See https://rustsec.org/advisories/RUSTSEC-2023-0045.html and https://github.com/advisories/GHSA-wfg4-322g-9vqv.